### PR TITLE
Add transformer-based naval trajectory forecasting pipeline

### DIFF
--- a/configs/trajectory_transformer.yaml
+++ b/configs/trajectory_transformer.yaml
@@ -1,0 +1,43 @@
+# Example configuration for training the trajectory transformer.
+# Update the CSV and GeoJSON paths to match your environment.
+
+data:
+  csv_path: data/data.csv
+  geojson_path: data/landmask.geojson
+  history_window: 12
+  forecast_horizon_minutes: 60
+  sample_rate_minutes: 10
+  cluster_destinations: true
+  destination_cluster_count: 64
+  minimum_track_length: 24
+  validation_fraction: 0.1
+  test_fraction: 0.1
+  random_seed: 42
+
+model:
+  input_dim: 12
+  static_feature_dim: 16
+  hidden_dim: 256
+  ff_dim: 512
+  num_heads: 8
+  num_layers: 6
+  dropout: 0.1
+  predict_steps: 6
+  num_destination_clusters: 64
+  destination_loss_weight: 0.5
+  land_penalty_weight: 5.0
+  geodesic_loss_weight: 1.0
+  velocity_loss_weight: 0.3
+  predict_speed: true
+  predict_heading: true
+
+training:
+  batch_size: 128
+  num_epochs: 50
+  learning_rate: 3.0e-4
+  weight_decay: 1.0e-4
+  lr_scheduler: cosine
+  gradient_clip_norm: 1.0
+  max_grad_norm: 1.0
+  mixed_precision: true
+  num_workers: 4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy>=1.23
+pandas>=2.0
+scikit-learn>=1.2
+shapely>=2.0
+PyYAML>=6.0
+torch>=2.0
+tqdm>=4.64

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ shapely>=2.0
 PyYAML>=6.0
 torch>=2.0
 tqdm>=4.64
+matplotlib>=3.7

--- a/ship_trajectory/README.md
+++ b/ship_trajectory/README.md
@@ -1,0 +1,52 @@
+# Transformer-based Naval Trajectory Forecasting
+
+This directory contains a full training pipeline for learning to forecast naval vessel trajectories up to one hour ahead using a Transformer-based model. The design focuses on:
+
+- **Meter-level predictions** derived from raw latitude/longitude inputs using local tangent plane projections.
+- **Land avoidance** via GeoJSON shoreline data that penalizes predicted points that intersect land.
+- **Destination awareness** with an auxiliary head that classifies a vessel's likely destination cluster.
+- **Physical priors** such as velocity, acceleration, and heading embeddings to stabilize roll-outs and avoid unrealistic jumps.
+- **Extensibility** for future battlefield context features and military installation influence.
+
+## Repository layout
+
+- [`config.py`](config.py): Dataclass definitions for data, model, and training configuration.
+- [`data.py`](data.py): Dataset utilities that create sliding windows from historical AIS-like tracks, normalize inputs, and attach per-sample anchors for absolute geodesic reconstruction.
+- [`landmask.py`](landmask.py): Thin wrapper around the provided GeoJSON polygons using `shapely` to support land-intersection checks.
+- [`model.py`](model.py): The Transformer encoder-decoder with learned future queries and auxiliary heads for speed, heading, and destination prediction.
+- [`train.py`](train.py): End-to-end training/evaluation script that enforces land avoidance, computes geodesic metrics, and reports 1 NM accuracy.
+- [`configs/trajectory_transformer.yaml`](../configs/trajectory_transformer.yaml): Example experiment configuration.
+
+## Data preparation
+
+1. **Historical tracks**: The dataset expects one CSV with the columns demonstrated in `data.csv` (`ph`, `mbmc`, `gjdq`, `type`, `time`, `mbc`, `mbv`, `mbh`, `lon`, `lat`). Observations must be at most 10 minutes apart. Tracks shorter than `minimum_track_length` are ignored.
+2. **GeoJSON land mask**: Supply a shoreline polygon collection that covers the operating theater. Land penalties discourage the model from producing infeasible trajectories.
+3. **Battlefield context (optional)**: Additional features (e.g., weather, threat level, ROE) can be encoded as environment tensors and passed to `TrajectoryTransformer.forward` via the `environment` argument. Update `ModelConfig.environment_dim` accordingly.
+4. **Military installations**: Curate installation coordinates and categorical metadata, then encode them per sample (e.g., distance-to-installation, affiliation). These can be concatenated to the dynamic features or fed through the environment context.
+
+## Training
+
+```bash
+python -m ship_trajectory.train --config configs/trajectory_transformer.yaml --output outputs/exp1
+```
+
+The script will:
+
+1. Split vessels into train/validation/test sets.
+2. Cluster historical endpoints (MiniBatchKMeans) to establish destination labels.
+3. Normalize motion features using only the training split statistics.
+4. Train with mixed precision and cosine learning rate decay.
+5. Penalize predictions that intersect land polygons and report one-hour geodesic errors.
+
+Metrics include mean per-step geodesic error, final-step error, and the percentage of trajectories finishing within **1 nautical mile** of ground truth.
+
+## Extending to battlefield and installation effects
+
+- **Battlefield simulation**: Generate synthetic environment tensors (e.g., vector fields for wind/current, restricted zones) and add them as additional inputs via the `environment` argument. During deployment, replace synthetic feeds with live upstream integrations.
+- **Military facility influence**: Pre-compute proximity features to known installations. You can extend `TrajectoryDataset` to append distances/angles to the nearest allied/hostile facility and let the Transformer learn routing biases (e.g., loitering near friendly bases, avoiding hostile SAM coverage).
+- **Terminal guidance**: The destination head can be swapped for a sequence of waypoints predicted via beam search if explicit path planning is required. The current cluster-based approach keeps the network aware of likely endpoints without hard-coding rules.
+
+## Expected performance
+
+With sufficient historical coverage (200k+ points as mentioned) and proper hyper-parameter tuning, the model is designed to keep the **1-hour forecast error under 1 NM** on validation data, provided the operating area is predominantly maritime. Use the validation statistics to tune the loss weights and adjust the land penalty strength for your region.
+

--- a/ship_trajectory/README.md
+++ b/ship_trajectory/README.md
@@ -15,6 +15,7 @@ This directory contains a full training pipeline for learning to forecast naval 
 - [`landmask.py`](landmask.py): Thin wrapper around the provided GeoJSON polygons using `shapely` to support land-intersection checks.
 - [`model.py`](model.py): The Transformer encoder-decoder with learned future queries and auxiliary heads for speed, heading, and destination prediction.
 - [`train.py`](train.py): End-to-end training/evaluation script that enforces land avoidance, computes geodesic metrics, and reports 1 NM accuracy.
+- [`predict.py`](predict.py): Single-sample inference and plotting utilities that visualise history, predictions, and ground truth tracks.
 - [`configs/trajectory_transformer.yaml`](../configs/trajectory_transformer.yaml): Example experiment configuration.
 
 ## Data preparation
@@ -39,6 +40,27 @@ The script will:
 5. Penalize predictions that intersect land polygons and report one-hour geodesic errors.
 
 Metrics include mean per-step geodesic error, final-step error, and the percentage of trajectories finishing within **1 nautical mile** of ground truth.
+
+## Inference & visualisation
+
+After training completes, load the best checkpoint and generate a qualitative plot for any split/sample:
+
+```bash
+python -m ship_trajectory.predict \
+  --config configs/trajectory_transformer.yaml \
+  --checkpoint outputs/exp1/best.pt \
+  --split test \
+  --index 0 \
+  --output outputs/exp1/sample0.png
+```
+
+The command also prints per-step mean error, final 60-minute error, and whether the trajectory lands within **1 NM**. The saved figure overlays:
+
+- Blue circles: historical input trajectory.
+- Green circles: ground-truth future path.
+- Red circles: model prediction (with an `X` on the predicted endpoint).
+
+For programmatic access, import `predict_sequence` and call it directly to obtain the `PredictionResult` dataclass with NumPy arrays and metrics.
 
 ## Extending to battlefield and installation effects
 

--- a/ship_trajectory/__init__.py
+++ b/ship_trajectory/__init__.py
@@ -1,0 +1,19 @@
+"""High-level package for trajectory forecasting models."""
+
+from .config import ModelConfig
+from .data import (
+    TrajectoryDataset,
+    TrajectoryDataModule,
+    VesselFeatureEncoder,
+)
+from .landmask import LandMask
+from .model import TrajectoryTransformer
+
+__all__ = [
+    "ModelConfig",
+    "TrajectoryDataset",
+    "TrajectoryDataModule",
+    "VesselFeatureEncoder",
+    "LandMask",
+    "TrajectoryTransformer",
+]

--- a/ship_trajectory/__init__.py
+++ b/ship_trajectory/__init__.py
@@ -7,6 +7,7 @@ from .data import (
     VesselFeatureEncoder,
 )
 from .landmask import LandMask
+from .interface import TrajectoryInferenceEngine
 from .model import TrajectoryTransformer
 from .predict import PredictionResult, predict_sequence
 
@@ -19,4 +20,5 @@ __all__ = [
     "TrajectoryTransformer",
     "PredictionResult",
     "predict_sequence",
+    "TrajectoryInferenceEngine",
 ]

--- a/ship_trajectory/__init__.py
+++ b/ship_trajectory/__init__.py
@@ -8,6 +8,7 @@ from .data import (
 )
 from .landmask import LandMask
 from .model import TrajectoryTransformer
+from .predict import PredictionResult, predict_sequence
 
 __all__ = [
     "ModelConfig",
@@ -16,4 +17,6 @@ __all__ = [
     "VesselFeatureEncoder",
     "LandMask",
     "TrajectoryTransformer",
+    "PredictionResult",
+    "predict_sequence",
 ]

--- a/ship_trajectory/config.py
+++ b/ship_trajectory/config.py
@@ -1,0 +1,90 @@
+"""Configuration dataclasses for the trajectory forecasting pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class TrainingConfig:
+    """Hyper-parameters that control training loops."""
+
+    batch_size: int = 128
+    num_epochs: int = 100
+    learning_rate: float = 3e-4
+    weight_decay: float = 1e-4
+    warmup_steps: int = 500
+    gradient_clip_norm: float = 1.0
+    num_workers: int = 8
+    lr_scheduler: str = "cosine"
+    label_smoothing: float = 0.0
+    max_grad_norm: float = 1.0
+    mixed_precision: bool = True
+
+
+@dataclass
+class ModelConfig:
+    """Top-level configuration for the trajectory transformer."""
+
+    input_dim: int = 12
+    static_feature_dim: int = 8
+    hidden_dim: int = 256
+    ff_dim: int = 512
+    num_heads: int = 8
+    num_layers: int = 6
+    dropout: float = 0.1
+    activation: str = "gelu"
+    predict_steps: int = 6
+    # destination head (cluster classification)
+    num_destination_clusters: int = 128
+    destination_loss_weight: float = 0.3
+    # land avoidance weighting
+    land_penalty_weight: float = 10.0
+    geodesic_loss_weight: float = 1.0
+    velocity_loss_weight: float = 0.3
+    # optional environment context embedding
+    environment_dim: Optional[int] = None
+    # optional auxiliary tasks (e.g., future speed prediction)
+    predict_speed: bool = True
+    predict_heading: bool = True
+
+
+@dataclass
+class DataConfig:
+    """Configuration describing data preprocessing behavior."""
+
+    csv_path: str
+    geojson_path: Optional[str] = None
+    time_column: str = "time"
+    vessel_id_column: str = "ph"
+    longitude_column: str = "lon"
+    latitude_column: str = "lat"
+    speed_column: str = "mbv"
+    course_column: str = "mbc"
+    heading_column: str = "mbh"
+    vessel_type_column: str = "type"
+    nation_column: str = "gjdq"
+    vessel_name_column: str = "mbmc"
+    sample_rate_minutes: int = 10
+    history_window: int = 12  # past timesteps (2 hours)
+    forecast_horizon_minutes: int = 60
+    normalize_numeric: bool = True
+    use_local_projection: bool = True
+    local_projection_anchor: Optional[List[float]] = None
+    cluster_destinations: bool = True
+    destination_cluster_count: int = 128
+    minimum_track_length: int = 18
+    validation_fraction: float = 0.1
+    test_fraction: float = 0.1
+    random_seed: int = 42
+
+
+@dataclass
+class ExperimentConfig:
+    """Bundle of configuration sections used during experiments."""
+
+    data: DataConfig
+    model: ModelConfig = field(default_factory=ModelConfig)
+    training: TrainingConfig = field(default_factory=TrainingConfig)
+

--- a/ship_trajectory/data.py
+++ b/ship_trajectory/data.py
@@ -1,0 +1,431 @@
+"""Dataset and dataloaders for trajectory forecasting."""
+
+from __future__ import annotations
+
+import json
+import math
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.cluster import MiniBatchKMeans
+from torch.utils.data import DataLoader, Dataset
+
+from .config import DataConfig
+from .landmask import LandMask
+
+METERS_PER_DEGREE_LAT = 111_320.0
+KNOT_TO_MPS = 0.514444
+
+
+def meters_per_degree_lon(lat: float) -> float:
+    """Approximate meters per degree of longitude at a specific latitude."""
+
+    return METERS_PER_DEGREE_LAT * math.cos(math.radians(lat))
+
+
+@dataclass
+class NormalizationStats:
+    mean: torch.Tensor
+    std: torch.Tensor
+
+    def transform(self, tensor: torch.Tensor) -> torch.Tensor:
+        return (tensor - self.mean) / (self.std + 1e-6)
+
+    def inverse(self, tensor: torch.Tensor) -> torch.Tensor:
+        return tensor * (self.std + 1e-6) + self.mean
+
+
+class VesselFeatureEncoder:
+    """Encodes categorical vessel metadata into embedding indices."""
+
+    def __init__(self, config: DataConfig):
+        self.config = config
+        self.type_to_idx: Dict[str, int] = {}
+        self.nation_to_idx: Dict[str, int] = {}
+        self.name_to_idx: Dict[str, int] = {}
+
+    def fit(self, df: pd.DataFrame) -> None:
+        type_values = sorted(df[self.config.vessel_type_column].fillna("<unk>").unique())
+        nation_values = sorted(df[self.config.nation_column].fillna("<unk>").unique())
+        name_values = sorted(df[self.config.vessel_name_column].fillna("<unk>").unique())
+
+        self.type_to_idx = {value: i for i, value in enumerate(["<unk>"] + type_values)}
+        self.nation_to_idx = {value: i for i, value in enumerate(["<unk>"] + nation_values)}
+        self.name_to_idx = {value: i for i, value in enumerate(["<unk>"] + name_values)}
+
+    def encode(self, row: pd.Series) -> Dict[str, int]:
+        return {
+            "type": self.type_to_idx.get(row.get(self.config.vessel_type_column), 0),
+            "nation": self.nation_to_idx.get(row.get(self.config.nation_column), 0),
+            "name": self.name_to_idx.get(row.get(self.config.vessel_name_column), 0),
+        }
+
+    @property
+    def embedding_dims(self) -> Dict[str, int]:
+        return {
+            "type": max(self.type_to_idx.values(), default=0) + 1,
+            "nation": max(self.nation_to_idx.values(), default=0) + 1,
+            "name": max(self.name_to_idx.values(), default=0) + 1,
+        }
+
+
+class DestinationClusterer:
+    """Clusters historical endpoints to provide destination classes."""
+
+    def __init__(self, num_clusters: int, random_state: int = 42):
+        self.num_clusters = num_clusters
+        self.random_state = random_state
+        self.model: Optional[MiniBatchKMeans] = None
+
+    def fit(self, coordinates: np.ndarray) -> None:
+        if coordinates.shape[0] < self.num_clusters:
+            raise ValueError(
+                "Number of destination clusters exceeds the number of unique samples"
+            )
+        self.model = MiniBatchKMeans(
+            n_clusters=self.num_clusters,
+            random_state=self.random_state,
+            batch_size=min(2048, coordinates.shape[0]),
+            max_iter=200,
+        )
+        self.model.fit(coordinates)
+
+    def predict(self, coordinates: np.ndarray) -> np.ndarray:
+        if self.model is None:
+            raise RuntimeError("DestinationClusterer must be fit before predicting")
+        return self.model.predict(coordinates)
+
+    def save(self, path: Path) -> None:
+        if self.model is None:
+            raise RuntimeError("DestinationClusterer must be fit before saving")
+        payload = {
+            "cluster_centers": self.model.cluster_centers_.tolist(),
+            "n_clusters": self.model.n_clusters,
+            "random_state": self.random_state,
+        }
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Path) -> "DestinationClusterer":
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        clusterer = cls(num_clusters=payload["n_clusters"], random_state=payload["random_state"])
+        clusterer.model = MiniBatchKMeans(n_clusters=payload["n_clusters"])
+        clusterer.model.cluster_centers_ = np.array(payload["cluster_centers"], dtype=np.float32)
+        return clusterer
+
+
+@dataclass
+class TrajectorySample:
+    history: torch.Tensor  # (history_window, feature_dim)
+    static: torch.Tensor  # (static_feature_dim,)
+    future_delta: torch.Tensor  # (predict_steps, 2) in meters
+    future_absolute: torch.Tensor  # (predict_steps, 2) in degrees (lon, lat)
+    anchor_lon: float
+    anchor_lat: float
+    future_speed: Optional[torch.Tensor]
+    future_course: Optional[torch.Tensor]
+    destination: Optional[int]
+
+
+class TrajectoryDataset(Dataset):
+    """PyTorch dataset for historical trajectory sequences."""
+
+    def __init__(
+        self,
+        config: DataConfig,
+        dataframe: pd.DataFrame,
+        encoder: VesselFeatureEncoder,
+        land_mask: Optional[LandMask] = None,
+        destination_clusterer: Optional[DestinationClusterer] = None,
+        split: str = "train",
+        normalization: Optional[NormalizationStats] = None,
+    ) -> None:
+        self.config = config
+        self.encoder = encoder
+        self.land_mask = land_mask
+        self.destination_clusterer = destination_clusterer
+        self.split = split
+        self.history_window = config.history_window
+        self.predict_steps = config.forecast_horizon_minutes // config.sample_rate_minutes
+        self.samples: List[TrajectorySample] = []
+        self.normalization: Optional[NormalizationStats] = normalization
+
+        self._prepare_samples(dataframe)
+        if config.normalize_numeric and self.samples:
+            if self.normalization is None:
+                self._compute_normalization()
+            self._apply_normalization()
+
+    def _prepare_samples(self, df: pd.DataFrame) -> None:
+        df = df.copy()
+        df[self.config.time_column] = pd.to_datetime(df[self.config.time_column])
+        df.sort_values([self.config.vessel_id_column, self.config.time_column], inplace=True)
+
+        track_groups = df.groupby(self.config.vessel_id_column)
+        random.seed(self.config.random_seed)
+
+        endpoint_coords: List[Tuple[float, float]] = []
+
+        for _, track in track_groups:
+            if len(track) < self.config.minimum_track_length:
+                continue
+            track = track.reset_index(drop=True)
+            track["delta_minutes"] = track[self.config.time_column].diff().dt.total_seconds().fillna(0) / 60.0
+
+            lats = track[self.config.latitude_column].to_numpy(dtype=np.float32)
+            lons = track[self.config.longitude_column].to_numpy(dtype=np.float32)
+            speeds = track[self.config.speed_column].to_numpy(dtype=np.float32)
+            courses = track[self.config.course_column].to_numpy(dtype=np.float32)
+            headings = track[self.config.heading_column].fillna(courses).to_numpy(dtype=np.float32)
+
+            static_encoded = self.encoder.encode(track.iloc[0])
+            static_tensor = torch.tensor([
+                static_encoded["type"],
+                static_encoded["nation"],
+                static_encoded["name"],
+            ], dtype=torch.long)
+
+            for start_idx in range(0, len(track) - self.history_window - self.predict_steps + 1):
+                history_slice = slice(start_idx, start_idx + self.history_window)
+                future_slice = slice(
+                    start_idx + self.history_window,
+                    start_idx + self.history_window + self.predict_steps,
+                )
+                history_lat = lats[history_slice]
+                history_lon = lons[history_slice]
+                future_lat = lats[future_slice]
+                future_lon = lons[future_slice]
+                future_speed = speeds[future_slice]
+                future_course = courses[future_slice]
+                history_speed = speeds[history_slice]
+                history_course = courses[history_slice]
+                history_heading = headings[history_slice]
+                history_delta_minutes = track["delta_minutes"].to_numpy(dtype=np.float32)[history_slice]
+
+                # Local tangent plane relative to last history point
+                anchor_lat = history_lat[-1]
+                anchor_lon = history_lon[-1]
+
+                lon_factor = meters_per_degree_lon(anchor_lat)
+                lat_factor = METERS_PER_DEGREE_LAT
+
+                history_positions = np.stack(
+                    [
+                        (history_lon - anchor_lon) * lon_factor,
+                        (history_lat - anchor_lat) * lat_factor,
+                    ],
+                    axis=-1,
+                )
+                course_rad = np.deg2rad(history_course)
+                heading_rad = np.deg2rad(history_heading)
+                history_speed_mps = history_speed * KNOT_TO_MPS
+                history_velocity = np.stack(
+                    [
+                        np.cos(course_rad) * history_speed_mps,
+                        np.sin(course_rad) * history_speed_mps,
+                    ],
+                    axis=-1,
+                )
+                acceleration = np.zeros_like(history_velocity)
+                delta_minutes = np.maximum(history_delta_minutes[1:, None], 1e-3)
+                acceleration[1:] = (history_velocity[1:] - history_velocity[:-1]) / (delta_minutes * 60.0)
+                acceleration[0] = acceleration[1]
+                heading_vector = np.stack([np.sin(heading_rad), np.cos(heading_rad)], axis=-1)
+                course_vector = np.stack([np.sin(course_rad), np.cos(course_rad)], axis=-1)
+                time_feature = history_delta_minutes[:, None] / self.config.sample_rate_minutes
+
+                history_features = np.concatenate(
+                    [
+                        history_positions,
+                        history_velocity,
+                        acceleration,
+                        history_speed_mps[:, None],
+                        heading_vector,
+                        course_vector,
+                        time_feature,
+                    ],
+                    axis=-1,
+                )
+
+                future_positions = np.stack(
+                    [
+                        (future_lon - anchor_lon) * lon_factor,
+                        (future_lat - anchor_lat) * lat_factor,
+                    ],
+                    axis=-1,
+                )
+                future_delta = future_positions - history_positions[-1]
+                future_absolute = np.stack([future_lon, future_lat], axis=-1)
+                future_speed_mps = future_speed * KNOT_TO_MPS
+
+                sample = TrajectorySample(
+                    history=torch.from_numpy(history_features).float(),
+                    static=static_tensor.clone(),
+                    future_delta=torch.from_numpy(future_delta).float(),
+                    future_absolute=torch.from_numpy(future_absolute).float(),
+                    anchor_lon=float(anchor_lon),
+                    anchor_lat=float(anchor_lat),
+                    future_speed=torch.from_numpy(future_speed_mps).float(),
+                    future_course=torch.from_numpy(future_course).float(),
+                    destination=None,
+                )
+
+                if self.destination_clusterer is not None:
+                    endpoint_coords.append((future_lon[-1], future_lat[-1]))
+                    # temporarily store, assign later after fitting clusterer
+                    sample.destination = -1
+
+                self.samples.append(sample)
+
+        if self.destination_clusterer is not None and endpoint_coords:
+            coords = np.asarray(endpoint_coords, dtype=np.float32)
+            if self.destination_clusterer.model is None and self.split == "train":
+                self.destination_clusterer.fit(coords)
+            if self.destination_clusterer.model is None:
+                raise RuntimeError(
+                    "Destination clusterer has not been fit; provide a trained model or run on train split first."
+                )
+            labels = self.destination_clusterer.predict(coords)
+            for sample, label in zip(self.samples, labels):
+                sample.destination = int(label)
+
+    def _compute_normalization(self) -> None:
+        histories = torch.stack([sample.history for sample in self.samples])
+        mean = histories.mean(dim=(0, 1))
+        std = histories.std(dim=(0, 1))
+        self.normalization = NormalizationStats(mean=mean, std=std)
+
+    def _apply_normalization(self) -> None:
+        assert self.normalization is not None
+        for sample in self.samples:
+            sample.history = self.normalization.transform(sample.history)
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, index: int) -> Dict[str, torch.Tensor]:
+        sample = self.samples[index]
+        payload: Dict[str, torch.Tensor] = {
+            "history": sample.history,
+            "static": sample.static,
+            "future_delta": sample.future_delta,
+            "future_absolute": sample.future_absolute,
+            "anchor_lon": torch.tensor(sample.anchor_lon, dtype=torch.float32),
+            "anchor_lat": torch.tensor(sample.anchor_lat, dtype=torch.float32),
+        }
+        if sample.future_speed is not None:
+            payload["future_speed"] = sample.future_speed
+        if sample.future_course is not None:
+            payload["future_course"] = sample.future_course
+        if sample.destination is not None and sample.destination >= 0:
+            payload["destination"] = torch.tensor(sample.destination, dtype=torch.long)
+        return payload
+
+
+def collate_batch(batch: Sequence[Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
+    keys = batch[0].keys()
+    collated: Dict[str, List[torch.Tensor]] = {key: [] for key in keys}
+    for sample in batch:
+        for key in keys:
+            collated[key].append(sample[key])
+    return {key: torch.stack(value) for key, value in collated.items()}
+
+
+class TrajectoryDataModule:
+    """Creates train/validation/test dataloaders for trajectory forecasting."""
+
+    def __init__(
+        self,
+        config: DataConfig,
+        land_mask: Optional[LandMask] = None,
+    ) -> None:
+        self.config = config
+        self.land_mask = land_mask
+        self.encoder = VesselFeatureEncoder(config)
+        self.destination_clusterer: Optional[DestinationClusterer] = None
+        if config.cluster_destinations:
+            self.destination_clusterer = DestinationClusterer(
+                num_clusters=config.destination_cluster_count,
+                random_state=config.random_seed,
+            )
+        self.train_dataset: Optional[TrajectoryDataset] = None
+        self.val_dataset: Optional[TrajectoryDataset] = None
+        self.test_dataset: Optional[TrajectoryDataset] = None
+
+    def load_dataframe(self) -> pd.DataFrame:
+        df = pd.read_csv(self.config.csv_path)
+        return df
+
+    def setup(self) -> None:
+        df = self.load_dataframe()
+        self.encoder.fit(df)
+
+        if self.destination_clusterer is not None:
+            # fit on entire dataset within TrajectoryDataset
+            pass
+
+        vessel_ids = df[self.config.vessel_id_column].unique().tolist()
+        random.Random(self.config.random_seed).shuffle(vessel_ids)
+        num_vessels = len(vessel_ids)
+        num_test = int(num_vessels * self.config.test_fraction)
+        num_val = int(num_vessels * self.config.validation_fraction)
+
+        test_ids = set(vessel_ids[:num_test])
+        val_ids = set(vessel_ids[num_test : num_test + num_val])
+
+        train_df = df[~df[self.config.vessel_id_column].isin(test_ids | val_ids)]
+        val_df = df[df[self.config.vessel_id_column].isin(val_ids)]
+        test_df = df[df[self.config.vessel_id_column].isin(test_ids)]
+
+        self.train_dataset = TrajectoryDataset(
+            config=self.config,
+            dataframe=train_df,
+            encoder=self.encoder,
+            land_mask=self.land_mask,
+            destination_clusterer=self.destination_clusterer,
+            split="train",
+        )
+        normalization = self.train_dataset.normalization
+        self.val_dataset = TrajectoryDataset(
+            config=self.config,
+            dataframe=val_df,
+            encoder=self.encoder,
+            land_mask=self.land_mask,
+            destination_clusterer=self.destination_clusterer,
+            split="val",
+            normalization=normalization,
+        )
+        self.test_dataset = TrajectoryDataset(
+            config=self.config,
+            dataframe=test_df,
+            encoder=self.encoder,
+            land_mask=self.land_mask,
+            destination_clusterer=self.destination_clusterer,
+            split="test",
+            normalization=normalization,
+        )
+
+    def dataloader(self, split: str, batch_size: int, num_workers: int = 0) -> DataLoader:
+        dataset_map = {
+            "train": self.train_dataset,
+            "val": self.val_dataset,
+            "test": self.test_dataset,
+        }
+        dataset = dataset_map.get(split)
+        if dataset is None:
+            raise ValueError(f"Unknown split {split}")
+
+        return DataLoader(
+            dataset,
+            batch_size=batch_size,
+            shuffle=(split == "train"),
+            num_workers=num_workers,
+            collate_fn=collate_batch,
+            drop_last=(split == "train"),
+        )
+

--- a/ship_trajectory/data.py
+++ b/ship_trajectory/data.py
@@ -181,7 +181,11 @@ class TrajectoryDataset(Dataset):
             lons = track[self.config.longitude_column].to_numpy(dtype=np.float32)
             speeds = track[self.config.speed_column].to_numpy(dtype=np.float32)
             courses = track[self.config.course_column].to_numpy(dtype=np.float32)
-            headings = track[self.config.heading_column].fillna(courses).to_numpy(dtype=np.float32)
+            headings = (
+                track[self.config.heading_column]
+                .fillna(track[self.config.course_column])
+                .to_numpy(dtype=np.float32)
+            )
 
             static_encoded = self.encoder.encode(track.iloc[0])
             static_tensor = torch.tensor([

--- a/ship_trajectory/interface.py
+++ b/ship_trajectory/interface.py
@@ -1,0 +1,345 @@
+"""Runtime inference helpers for external integrations."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+import torch
+
+from .data import (
+    METERS_PER_DEGREE_LAT,
+    KNOT_TO_MPS,
+    TrajectoryDataModule,
+    meters_per_degree_lon,
+)
+from .landmask import LandMask
+from .model import TrajectoryTransformer
+from .train import haversine_distance, load_config, set_seed
+
+
+def _prepare_land_mask(path: Optional[str]) -> Optional[LandMask]:
+    if path:
+        return LandMask(Path(path))
+    return None
+
+
+def _safe_float(value: Optional[object]) -> float:
+    if value is None or value == "":
+        return float("nan")
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def _parse_time(value: Optional[object]) -> Optional[pd.Timestamp]:
+    if value is None or value == "":
+        return None
+    try:
+        ts = pd.to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    return ts
+
+
+def _normalize_angle(angle_deg: np.ndarray) -> np.ndarray:
+    return np.mod(angle_deg + 360.0, 360.0)
+
+
+@dataclass
+class PredictionStep:
+    lon: float
+    lat: float
+    mbH: float
+    mbV: float
+
+
+class TrajectoryInferenceEngine:
+    """Loads a trained model and exposes a lightweight prediction API."""
+
+    def __init__(
+        self,
+        config_path: Path,
+        checkpoint_path: Path,
+        device: Optional[str] = None,
+    ) -> None:
+        self.config = load_config(Path(config_path))
+        set_seed(self.config.data.random_seed)
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+
+        self.land_mask = _prepare_land_mask(self.config.data.geojson_path)
+        self.datamodule = TrajectoryDataModule(self.config.data, self.land_mask)
+        self.datamodule.setup()
+
+        if self.datamodule.train_dataset is None:
+            raise RuntimeError("Training dataset failed to initialise; check CSV path")
+
+        self.normalization = self.datamodule.train_dataset.normalization
+        self.history_window = self.datamodule.train_dataset.history_window
+        self.step_minutes = self.config.data.sample_rate_minutes
+
+        self.model = TrajectoryTransformer(
+            self.config.model, self.datamodule.encoder.embedding_dims
+        )
+        payload = torch.load(Path(checkpoint_path), map_location=self.device)
+        state_dict = payload.get("model_state", payload)
+        self.model.load_state_dict(state_dict)
+        self.model.to(self.device)
+        self.model.eval()
+
+    def predict(
+        self,
+        history: Sequence[Dict[str, object]],
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> List[Dict[str, float]]:
+        """Forecast future trajectory steps for an arbitrary history window."""
+
+        if len(history) < self.history_window:
+            raise ValueError(
+                f"Expected at least {self.history_window} history points, "
+                f"got {len(history)}"
+            )
+
+        history_tensor, anchor_lon, anchor_lat = self._encode_history(history)
+        static_tensor = self._encode_static(metadata or history[-1])
+
+        history_tensor = history_tensor.unsqueeze(0).to(self.device)
+        static_tensor = static_tensor.unsqueeze(0).to(self.device)
+        anchor_lon_tensor = torch.tensor([anchor_lon], dtype=torch.float32, device=self.device)
+        anchor_lat_tensor = torch.tensor([anchor_lat], dtype=torch.float32, device=self.device)
+
+        with torch.no_grad():
+            outputs = self.model.autoregressive_predict(
+                history_tensor,
+                static_tensor,
+                anchor_lat=anchor_lat_tensor,
+                anchor_lon=anchor_lon_tensor,
+            )
+
+        pred_lon = outputs["pred_lon"].squeeze(0).cpu().numpy()
+        pred_lat = outputs["pred_lat"].squeeze(0).cpu().numpy()
+
+        heading_deg = None
+        if "heading" in outputs:
+            heading_vec = outputs["heading"].squeeze(0).cpu().numpy()
+            heading_deg = np.degrees(np.arctan2(heading_vec[:, 0], heading_vec[:, 1]))
+            heading_deg = _normalize_angle(heading_deg)
+
+        speed_knots = None
+        if "speed" in outputs:
+            speed_mps = outputs["speed"].squeeze(0).cpu().numpy()
+            speed_knots = speed_mps / KNOT_TO_MPS
+
+        steps = self._format_predictions(
+            pred_lon,
+            pred_lat,
+            heading_deg,
+            speed_knots,
+            anchor_lon,
+            anchor_lat,
+        )
+        return [step.__dict__ for step in steps]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _encode_history(
+        self, history: Sequence[Dict[str, object]]
+    ) -> tuple[torch.Tensor, float, float]:
+        records = list(history)[-self.history_window :]
+
+        lons = np.array([
+            _safe_float(item.get(self.config.data.longitude_column, item.get("rpLong")))
+            for item in records
+        ], dtype=np.float32)
+        lats = np.array([
+            _safe_float(item.get(self.config.data.latitude_column, item.get("lat")))
+            for item in records
+        ], dtype=np.float32)
+        speeds = np.array([
+            _safe_float(item.get(self.config.data.speed_column, item.get("v")))
+            for item in records
+        ], dtype=np.float32)
+        courses = np.array([
+            _safe_float(item.get(self.config.data.course_column, item.get("mbc")))
+            for item in records
+        ], dtype=np.float32)
+        headings = np.array([
+            _safe_float(item.get(self.config.data.heading_column, item.get("h")))
+            for item in records
+        ], dtype=np.float32)
+
+        times = [_parse_time(item.get("time")) for item in records]
+        delta_minutes = np.zeros(len(records), dtype=np.float32)
+        for idx in range(1, len(records)):
+            t_curr, t_prev = times[idx], times[idx - 1]
+            if t_curr is not None and t_prev is not None:
+                delta = (t_curr - t_prev).total_seconds() / 60.0
+                if not math.isfinite(delta) or delta <= 0:
+                    delta = float(self.step_minutes)
+            else:
+                delta = float(self.step_minutes)
+            delta_minutes[idx] = float(delta)
+
+        anchor_lat = float(lats[-1])
+        anchor_lon = float(lons[-1])
+        lon_factor = meters_per_degree_lon(anchor_lat)
+
+        courses = np.where(np.isfinite(courses), courses, headings)
+        headings = np.where(np.isfinite(headings), headings, courses)
+
+        if not np.all(np.isfinite(courses)):
+            derived = np.copy(courses)
+            for idx in range(len(courses) - 1):
+                if math.isfinite(derived[idx]):
+                    continue
+                dlon = (lons[idx + 1] - lons[idx]) * meters_per_degree_lon(float(lats[idx]))
+                dlat = (lats[idx + 1] - lats[idx]) * METERS_PER_DEGREE_LAT
+                if dlon == 0.0 and dlat == 0.0:
+                    continue
+                angle = math.degrees(math.atan2(dlat, dlon))
+                derived[idx] = angle
+            if len(derived) > 1 and not math.isfinite(derived[-1]):
+                derived[-1] = derived[-2]
+            courses = np.where(np.isfinite(courses), courses, derived)
+
+        if not np.all(np.isfinite(headings)):
+            headings = np.where(np.isfinite(headings), headings, courses)
+
+        courses = np.where(np.isfinite(courses), courses, 0.0)
+        headings = np.where(np.isfinite(headings), headings, 0.0)
+
+        courses = _normalize_angle(courses.astype(np.float32))
+        headings = _normalize_angle(headings.astype(np.float32))
+
+        speed_mps = speeds * KNOT_TO_MPS
+        if not np.all(np.isfinite(speed_mps)):
+            derived_speed = np.zeros_like(speed_mps)
+            for idx in range(1, len(records)):
+                lon_fac = meters_per_degree_lon(float(lats[idx - 1]))
+                dx = (lons[idx] - lons[idx - 1]) * lon_fac
+                dy = (lats[idx] - lats[idx - 1]) * METERS_PER_DEGREE_LAT
+                distance = math.hypot(dx, dy)
+                dt = max(delta_minutes[idx], 1e-3) * 60.0
+                derived_speed[idx] = distance / dt
+            if len(derived_speed) > 1:
+                derived_speed[0] = derived_speed[1]
+            speed_mps = np.where(np.isfinite(speed_mps), speed_mps, derived_speed)
+
+        history_positions = np.stack(
+            [
+                (lons - anchor_lon) * lon_factor,
+                (lats - anchor_lat) * METERS_PER_DEGREE_LAT,
+            ],
+            axis=-1,
+        )
+
+        course_rad = np.deg2rad(courses)
+        heading_rad = np.deg2rad(headings)
+        history_velocity = np.stack(
+            [np.cos(course_rad) * speed_mps, np.sin(course_rad) * speed_mps],
+            axis=-1,
+        )
+
+        acceleration = np.zeros_like(history_velocity)
+        if len(records) > 1:
+            delta_seconds = np.maximum(delta_minutes[1:, None], 1e-3) * 60.0
+            acceleration[1:] = (history_velocity[1:] - history_velocity[:-1]) / delta_seconds
+            acceleration[0] = acceleration[1]
+
+        heading_vector = np.stack([np.sin(heading_rad), np.cos(heading_rad)], axis=-1)
+        course_vector = np.stack([np.sin(course_rad), np.cos(course_rad)], axis=-1)
+        time_feature = delta_minutes[:, None] / float(self.step_minutes)
+        speed_feature = speed_mps[:, None]
+
+        history_features = np.concatenate(
+            [
+                history_positions,
+                history_velocity,
+                acceleration,
+                speed_feature,
+                heading_vector,
+                course_vector,
+                time_feature,
+            ],
+            axis=-1,
+        )
+
+        history_tensor = torch.from_numpy(history_features).float()
+        if self.normalization is not None:
+            history_tensor = self.normalization.transform(history_tensor)
+
+        return history_tensor, anchor_lon, anchor_lat
+
+    def _encode_static(self, metadata: Dict[str, object]) -> torch.Tensor:
+        type_key = self.config.data.vessel_type_column
+        nation_key = self.config.data.nation_column
+        name_key = self.config.data.vessel_name_column
+
+        vessel_type = metadata.get(type_key) or metadata.get("type") or "<unk>"
+        nation = metadata.get(nation_key) or metadata.get("gjdq") or "<unk>"
+        name = metadata.get(name_key) or metadata.get("mbmc") or "<unk>"
+
+        encoder = self.datamodule.encoder
+        type_idx = encoder.type_to_idx.get(str(vessel_type), 0)
+        nation_idx = encoder.nation_to_idx.get(str(nation), 0)
+        name_idx = encoder.name_to_idx.get(str(name), 0)
+
+        static_tensor = torch.tensor([type_idx, nation_idx, name_idx], dtype=torch.long)
+        return static_tensor
+
+    def _format_predictions(
+        self,
+        pred_lon: np.ndarray,
+        pred_lat: np.ndarray,
+        heading_deg: Optional[np.ndarray],
+        speed_knots: Optional[np.ndarray],
+        anchor_lon: float,
+        anchor_lat: float,
+    ) -> List[PredictionStep]:
+        steps: List[PredictionStep] = []
+
+        if heading_deg is None:
+            prev_lon = np.concatenate(([anchor_lon], pred_lon[:-1]))
+            prev_lat = np.concatenate(([anchor_lat], pred_lat[:-1]))
+            headings = []
+            for lon_prev, lat_prev, lon_curr, lat_curr in zip(
+                prev_lon, prev_lat, pred_lon, pred_lat
+            ):
+                lon_fac = meters_per_degree_lon(float(lat_prev))
+                dx = (lon_curr - lon_prev) * lon_fac
+                dy = (lat_curr - lat_prev) * METERS_PER_DEGREE_LAT
+                angle = math.degrees(math.atan2(dx, dy))
+                headings.append((angle + 360.0) % 360.0)
+            heading_deg = np.asarray(headings, dtype=np.float32)
+
+        if speed_knots is None:
+            prev_lon = np.concatenate(([anchor_lon], pred_lon[:-1]))
+            prev_lat = np.concatenate(([anchor_lat], pred_lat[:-1]))
+            lon_t = torch.from_numpy(prev_lon)
+            lat_t = torch.from_numpy(prev_lat)
+            next_lon_t = torch.from_numpy(pred_lon)
+            next_lat_t = torch.from_numpy(pred_lat)
+            distances = haversine_distance(lon_t, lat_t, next_lon_t, next_lat_t).numpy()
+            speed_mps = distances / (self.step_minutes * 60.0)
+            speed_knots = speed_mps / KNOT_TO_MPS
+
+        heading_deg = _normalize_angle(heading_deg.astype(np.float32))
+        speed_knots = speed_knots.astype(np.float32)
+
+        for lon, lat, hdg, spd in zip(pred_lon, pred_lat, heading_deg, speed_knots):
+            steps.append(
+                PredictionStep(
+                    lon=float(lon),
+                    lat=float(lat),
+                    mbH=float(hdg),
+                    mbV=float(spd),
+                )
+            )
+        return steps
+

--- a/ship_trajectory/landmask.py
+++ b/ship_trajectory/landmask.py
@@ -1,0 +1,38 @@
+"""GeoJSON-based land avoidance utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+from shapely.geometry import Point, shape
+from shapely.strtree import STRtree
+
+
+class LandMask:
+    """Spatial index for fast land collision checks."""
+
+    def __init__(self, geojson_path: Path) -> None:
+        geojson = json.loads(Path(geojson_path).read_text(encoding="utf-8"))
+        features = geojson.get("features", [])
+        self.polygons = [shape(feature["geometry"]) for feature in features]
+        self.index = STRtree(self.polygons)
+
+    def intersects(self, lon: float, lat: float) -> bool:
+        point = Point(lon, lat)
+        for polygon in self.index.query(point):
+            if polygon.contains(point):
+                return True
+        return False
+
+    def batch_intersects(self, coordinates: Iterable[Tuple[float, float]]) -> List[bool]:
+        return [self.intersects(lon, lat) for lon, lat in coordinates]
+
+    def distance_to_land(self, lon: float, lat: float) -> float:
+        point = Point(lon, lat)
+        distances = [polygon.exterior.distance(point) for polygon in self.polygons]
+        if not distances:
+            return float("inf")
+        return min(distances)
+

--- a/ship_trajectory/model.py
+++ b/ship_trajectory/model.py
@@ -1,0 +1,187 @@
+"""Transformer-based trajectory forecasting model."""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .config import ModelConfig
+
+
+class PositionalEncoding(nn.Module):
+    def __init__(self, d_model: int, dropout: float = 0.1, max_len: int = 5000):
+        super().__init__()
+        self.dropout = nn.Dropout(p=dropout)
+
+        position = torch.arange(0, max_len).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, d_model, 2) * (-math.log(10000.0) / d_model)
+        )
+        pe = torch.zeros(max_len, d_model)
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.register_buffer("pe", pe)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.pe[:, : x.size(1)]
+        return self.dropout(x)
+
+
+class StaticEmbedding(nn.Module):
+    def __init__(self, type_vocab: int, nation_vocab: int, name_vocab: int, dim: int):
+        super().__init__()
+        self.type_embedding = nn.Embedding(type_vocab, dim)
+        self.nation_embedding = nn.Embedding(nation_vocab, dim)
+        self.name_embedding = nn.Embedding(name_vocab, dim)
+        self.proj = nn.Linear(dim * 3, dim)
+
+    def forward(self, static: torch.Tensor) -> torch.Tensor:
+        ship_type, nation, name = static.unbind(dim=-1)
+        type_emb = self.type_embedding(ship_type)
+        nation_emb = self.nation_embedding(nation)
+        name_emb = self.name_embedding(name)
+        concat = torch.cat([type_emb, nation_emb, name_emb], dim=-1)
+        return self.proj(concat)
+
+
+class TrajectoryTransformer(nn.Module):
+    """Transformer encoder-decoder for multi-step trajectory prediction."""
+
+    def __init__(self, config: ModelConfig, encoder_vocab: Dict[str, int]):
+        super().__init__()
+        self.config = config
+        self.input_proj = nn.Linear(config.input_dim, config.hidden_dim)
+        self.positional_encoding = PositionalEncoding(config.hidden_dim, dropout=config.dropout)
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=config.hidden_dim,
+            nhead=config.num_heads,
+            dim_feedforward=config.ff_dim,
+            dropout=config.dropout,
+            batch_first=True,
+            activation=config.activation,
+            norm_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=config.num_layers)
+
+        decoder_layer = nn.TransformerDecoderLayer(
+            d_model=config.hidden_dim,
+            nhead=config.num_heads,
+            dim_feedforward=config.ff_dim,
+            dropout=config.dropout,
+            batch_first=True,
+            activation=config.activation,
+            norm_first=True,
+        )
+        self.decoder = nn.TransformerDecoder(decoder_layer, num_layers=2)
+
+        self.future_queries = nn.Parameter(
+            torch.randn(config.predict_steps, config.hidden_dim)
+        )
+
+        static_dim = config.hidden_dim
+        self.static_embedding = StaticEmbedding(
+            type_vocab=encoder_vocab["type"],
+            nation_vocab=encoder_vocab["nation"],
+            name_vocab=encoder_vocab["name"],
+            dim=config.static_feature_dim,
+        )
+        self.static_proj = nn.Sequential(
+            nn.Linear(config.static_feature_dim, config.hidden_dim),
+            nn.LayerNorm(config.hidden_dim),
+            nn.ReLU(),
+        )
+
+        if config.environment_dim:
+            self.environment_proj = nn.Linear(config.environment_dim, config.hidden_dim)
+        else:
+            self.environment_proj = None
+
+        self.position_head = nn.Linear(config.hidden_dim, 2)
+        if config.predict_speed:
+            self.speed_head = nn.Linear(config.hidden_dim, 1)
+        else:
+            self.speed_head = None
+        if config.predict_heading:
+            self.heading_head = nn.Linear(config.hidden_dim, 2)
+        else:
+            self.heading_head = None
+
+        self.destination_head = nn.Sequential(
+            nn.LayerNorm(config.hidden_dim),
+            nn.Linear(config.hidden_dim, config.num_destination_clusters),
+        )
+
+    def forward(
+        self,
+        history: torch.Tensor,
+        static: torch.Tensor,
+        environment: Optional[torch.Tensor] = None,
+    ) -> Dict[str, torch.Tensor]:
+        # history: (batch, seq_len, feature_dim)
+        x = self.input_proj(history)
+        x = self.positional_encoding(x)
+        memory = self.encoder(x)
+
+        batch_size = history.shape[0]
+        queries = self.future_queries.unsqueeze(0).expand(batch_size, -1, -1)
+
+        static_embedding = self.static_embedding(static)
+        static_embedding = self.static_proj(static_embedding)
+        static_embedding = static_embedding.unsqueeze(1)
+
+        if environment is not None and self.environment_proj is not None:
+            env_proj = self.environment_proj(environment)
+            env_proj = env_proj.unsqueeze(1)
+            memory = memory + env_proj
+
+        memory = memory + static_embedding
+
+        decoded = self.decoder(queries, memory)
+
+        position = self.position_head(decoded)
+        outputs: Dict[str, torch.Tensor] = {"delta_xy": position}
+
+        if self.speed_head is not None:
+            outputs["speed"] = self.speed_head(decoded).squeeze(-1)
+        if self.heading_head is not None:
+            heading_raw = self.heading_head(decoded)
+            outputs["heading"] = F.normalize(heading_raw, dim=-1)
+
+        pooled = memory.mean(dim=1)
+        outputs["destination_logits"] = self.destination_head(pooled)
+
+        return outputs
+
+    def autoregressive_predict(
+        self,
+        history: torch.Tensor,
+        static: torch.Tensor,
+        environment: Optional[torch.Tensor] = None,
+        step_minutes: int = 10,
+        anchor_lat: Optional[torch.Tensor] = None,
+        anchor_lon: Optional[torch.Tensor] = None,
+    ) -> Dict[str, torch.Tensor]:
+        """Predict absolute coordinates by integrating predicted displacements."""
+
+        outputs = self.forward(history, static, environment)
+        delta_xy = outputs["delta_xy"]  # meters
+        cumulative = delta_xy.cumsum(dim=1)
+        if anchor_lat is None or anchor_lon is None:
+            raise ValueError("anchor_lat and anchor_lon must be provided for absolute predictions")
+
+        meters_per_deg_lat = 111_320.0
+        meters_per_deg_lon = (math.pi / 180.0) * 6378137.0 * torch.cos(torch.deg2rad(anchor_lat))
+        lon_offset = cumulative[..., 0] / meters_per_deg_lon
+        lat_offset = cumulative[..., 1] / meters_per_deg_lat
+        pred_lon = anchor_lon.unsqueeze(1) + lon_offset
+        pred_lat = anchor_lat.unsqueeze(1) + lat_offset
+        outputs["pred_lon"] = pred_lon
+        outputs["pred_lat"] = pred_lat
+        return outputs
+

--- a/ship_trajectory/predict.py
+++ b/ship_trajectory/predict.py
@@ -1,0 +1,224 @@
+"""Inference helper to evaluate and visualise trajectory forecasts."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+from .config import ExperimentConfig
+from .data import METERS_PER_DEGREE_LAT, TrajectoryDataModule, meters_per_degree_lon
+from .landmask import LandMask
+from .model import TrajectoryTransformer
+from .train import haversine_distance, load_config, set_seed
+
+NAUTICAL_MILE_METERS = 1852.0
+
+
+@dataclass
+class PredictionResult:
+    """Container with prediction arrays and evaluation metrics."""
+
+    history_lon: np.ndarray
+    history_lat: np.ndarray
+    target_lon: np.ndarray
+    target_lat: np.ndarray
+    pred_lon: np.ndarray
+    pred_lat: np.ndarray
+    step_errors: np.ndarray
+    mean_error_m: float
+    final_error_m: float
+    within_one_nm: bool
+
+
+def _prepare_land_mask(config: ExperimentConfig) -> Optional[LandMask]:
+    if config.data.geojson_path:
+        return LandMask(Path(config.data.geojson_path))
+    return None
+
+
+def _load_model(
+    experiment: ExperimentConfig,
+    datamodule: TrajectoryDataModule,
+    checkpoint: Path,
+    device: torch.device,
+) -> TrajectoryTransformer:
+    model = TrajectoryTransformer(experiment.model, datamodule.encoder.embedding_dims)
+    payload = torch.load(checkpoint, map_location=device)
+    state_dict = payload.get("model_state", payload)
+    model.load_state_dict(state_dict)
+    model.to(device)
+    model.eval()
+    return model
+
+
+def _reconstruct_history(
+    datamodule: TrajectoryDataModule,
+    split: str,
+    index: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    dataset = getattr(datamodule, f"{split}_dataset")
+    if dataset is None:
+        raise ValueError(f"Dataset for split '{split}' has not been initialised")
+    if index < 0 or index >= len(dataset.samples):
+        raise IndexError(
+            f"Sample index {index} out of range for split '{split}' with {len(dataset.samples)} samples"
+        )
+
+    sample = dataset.samples[index]
+    history = sample.history.clone()
+    if dataset.normalization is not None:
+        history = dataset.normalization.inverse(history)
+
+    history_positions = history[:, :2].numpy()
+    lon_factor = meters_per_degree_lon(sample.anchor_lat)
+    history_lon = sample.anchor_lon + history_positions[:, 0] / lon_factor
+    history_lat = sample.anchor_lat + history_positions[:, 1] / METERS_PER_DEGREE_LAT
+    return history_lon, history_lat
+
+
+def predict_sequence(
+    config_path: Path,
+    checkpoint_path: Path,
+    split: str = "test",
+    sample_index: int = 0,
+    output_path: Optional[Path] = None,
+    show: bool = False,
+) -> PredictionResult:
+    """Run inference on a single sample and optionally visualise the trajectory."""
+
+    experiment = load_config(config_path)
+    set_seed(experiment.data.random_seed)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    land_mask = _prepare_land_mask(experiment)
+
+    datamodule = TrajectoryDataModule(experiment.data, land_mask)
+    datamodule.setup()
+
+    dataset = getattr(datamodule, f"{split}_dataset")
+    if dataset is None:
+        raise ValueError(f"Split '{split}' is not available. Choose from train/val/test.")
+    if sample_index < 0 or sample_index >= len(dataset):
+        raise IndexError(
+            f"Sample index {sample_index} out of range for split '{split}' with {len(dataset)} samples"
+        )
+
+    model = _load_model(experiment, datamodule, checkpoint_path, device)
+
+    sample = dataset[sample_index]
+    history = sample["history"].unsqueeze(0).to(device)
+    static = sample["static"].unsqueeze(0).to(device)
+    anchor_lon = sample["anchor_lon"].unsqueeze(0).to(device)
+    anchor_lat = sample["anchor_lat"].unsqueeze(0).to(device)
+
+    with torch.no_grad():
+        outputs = model.autoregressive_predict(
+            history,
+            static,
+            anchor_lat=anchor_lat,
+            anchor_lon=anchor_lon,
+        )
+    pred_lon = outputs["pred_lon"].squeeze(0).cpu().numpy()
+    pred_lat = outputs["pred_lat"].squeeze(0).cpu().numpy()
+
+    target = sample["future_absolute"].cpu().numpy()
+    target_lon = target[:, 0]
+    target_lat = target[:, 1]
+
+    error_tensor = haversine_distance(
+        torch.from_numpy(pred_lon),
+        torch.from_numpy(pred_lat),
+        torch.from_numpy(target_lon),
+        torch.from_numpy(target_lat),
+    )
+    step_errors = error_tensor.cpu().numpy()
+    mean_error = float(step_errors.mean())
+    final_error = float(step_errors[-1])
+    within_one_nm = bool(final_error < NAUTICAL_MILE_METERS)
+
+    history_lon, history_lat = _reconstruct_history(datamodule, split, sample_index)
+
+    result = PredictionResult(
+        history_lon=history_lon,
+        history_lat=history_lat,
+        target_lon=target_lon,
+        target_lat=target_lat,
+        pred_lon=pred_lon,
+        pred_lat=pred_lat,
+        step_errors=step_errors,
+        mean_error_m=mean_error,
+        final_error_m=final_error,
+        within_one_nm=within_one_nm,
+    )
+
+    if output_path is not None or show:
+        _visualise_prediction(result, output_path, show)
+
+    return result
+
+
+def _visualise_prediction(result: PredictionResult, output_path: Optional[Path], show: bool) -> None:
+    history_future_lon = np.concatenate(([result.history_lon[-1]], result.target_lon))
+    history_future_lat = np.concatenate(([result.history_lat[-1]], result.target_lat))
+    pred_future_lon = np.concatenate(([result.history_lon[-1]], result.pred_lon))
+    pred_future_lat = np.concatenate(([result.history_lat[-1]], result.pred_lat))
+
+    plt.figure(figsize=(8, 6))
+    plt.plot(result.history_lon, result.history_lat, "-o", label="History", color="#1f77b4")
+    plt.plot(history_future_lon, history_future_lat, "-o", label="Ground truth", color="#2ca02c")
+    plt.plot(pred_future_lon, pred_future_lat, "-o", label="Prediction", color="#d62728")
+    plt.scatter(result.pred_lon[-1], result.pred_lat[-1], color="#d62728", marker="x", s=80)
+    plt.scatter(result.target_lon[-1], result.target_lat[-1], color="#2ca02c", marker="s", s=60)
+
+    title = (
+        f"Mean error: {result.mean_error_m:.1f} m | Final: {result.final_error_m:.1f} m | "
+        f"Within 1 NM: {'yes' if result.within_one_nm else 'no'}"
+    )
+    plt.title(title)
+    plt.xlabel("Longitude")
+    plt.ylabel("Latitude")
+    plt.legend()
+    plt.grid(True, linestyle="--", alpha=0.4)
+    plt.tight_layout()
+
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        plt.savefig(output_path, dpi=200)
+    if show:
+        plt.show()
+    plt.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run inference on a trained trajectory transformer")
+    parser.add_argument("--config", type=Path, required=True, help="Path to the experiment YAML configuration")
+    parser.add_argument("--checkpoint", type=Path, required=True, help="Path to the trained model checkpoint")
+    parser.add_argument("--split", type=str, default="test", choices=["train", "val", "test"], help="Dataset split")
+    parser.add_argument("--index", type=int, default=0, help="Sample index within the chosen split")
+    parser.add_argument("--output", type=Path, default=None, help="Optional path to save the plot image")
+    parser.add_argument("--show", action="store_true", help="Display the plot interactively")
+    args = parser.parse_args()
+
+    result = predict_sequence(
+        config_path=args.config,
+        checkpoint_path=args.checkpoint,
+        split=args.split,
+        sample_index=args.index,
+        output_path=args.output,
+        show=args.show,
+    )
+
+    print(
+        f"Per-step mean error: {result.mean_error_m:.2f} m | Final error: {result.final_error_m:.2f} m | "
+        f"Within 1 NM: {'yes' if result.within_one_nm else 'no'}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ship_trajectory/predict.py
+++ b/ship_trajectory/predict.py
@@ -11,11 +11,29 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 
-from .config import ExperimentConfig
-from .data import METERS_PER_DEGREE_LAT, TrajectoryDataModule, meters_per_degree_lon
-from .landmask import LandMask
-from .model import TrajectoryTransformer
-from .train import haversine_distance, load_config, set_seed
+if __package__ in (None, ""):
+    # Allow running as a standalone script (e.g. `python predict.py`).
+    import sys
+
+    package_root = Path(__file__).resolve().parent.parent
+    if str(package_root) not in sys.path:
+        sys.path.insert(0, str(package_root))
+
+    from ship_trajectory.config import ExperimentConfig
+    from ship_trajectory.data import (
+        METERS_PER_DEGREE_LAT,
+        TrajectoryDataModule,
+        meters_per_degree_lon,
+    )
+    from ship_trajectory.landmask import LandMask
+    from ship_trajectory.model import TrajectoryTransformer
+    from ship_trajectory.train import haversine_distance, load_config, set_seed
+else:
+    from .config import ExperimentConfig
+    from .data import METERS_PER_DEGREE_LAT, TrajectoryDataModule, meters_per_degree_lon
+    from .landmask import LandMask
+    from .model import TrajectoryTransformer
+    from .train import haversine_distance, load_config, set_seed
 
 NAUTICAL_MILE_METERS = 1852.0
 

--- a/ship_trajectory/train.py
+++ b/ship_trajectory/train.py
@@ -1,0 +1,338 @@
+"""Training script for the trajectory transformer model."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import random
+from dataclasses import asdict
+from pathlib import Path
+from typing import Dict, Optional
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+import yaml
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import CosineAnnealingLR, LambdaLR
+from tqdm.auto import tqdm
+
+from .config import DataConfig, ExperimentConfig, ModelConfig, TrainingConfig
+from .data import METERS_PER_DEGREE_LAT, TrajectoryDataModule
+from .landmask import LandMask
+from .model import TrajectoryTransformer
+
+NAUTICAL_MILE_METERS = 1852.0
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def load_config(path: Path) -> ExperimentConfig:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle)
+    data_cfg = DataConfig(**payload["data"])
+    model_cfg = ModelConfig(**payload.get("model", {}))
+    training_cfg = TrainingConfig(**payload.get("training", {}))
+    return ExperimentConfig(data=data_cfg, model=model_cfg, training=training_cfg)
+
+
+def haversine_distance(
+    lon1: torch.Tensor,
+    lat1: torch.Tensor,
+    lon2: torch.Tensor,
+    lat2: torch.Tensor,
+) -> torch.Tensor:
+    """Compute great-circle distance in meters."""
+
+    lon1_rad, lat1_rad = torch.deg2rad(lon1), torch.deg2rad(lat1)
+    lon2_rad, lat2_rad = torch.deg2rad(lon2), torch.deg2rad(lat2)
+    dlon = lon2_rad - lon1_rad
+    dlat = lat2_rad - lat1_rad
+    a = torch.sin(dlat / 2) ** 2 + torch.cos(lat1_rad) * torch.cos(lat2_rad) * torch.sin(dlon / 2) ** 2
+    c = 2 * torch.atan2(torch.sqrt(a), torch.sqrt(1 - a))
+    return 6378137.0 * c
+
+
+def create_scheduler(
+    optimizer: torch.optim.Optimizer,
+    training_cfg: TrainingConfig,
+    total_steps: int,
+) -> Optional[torch.optim.lr_scheduler._LRScheduler]:
+    if training_cfg.lr_scheduler == "cosine":
+        return CosineAnnealingLR(optimizer, T_max=total_steps)
+    if training_cfg.lr_scheduler == "linear":
+        def lr_lambda(step: int) -> float:
+            return max(0.0, 1 - step / float(total_steps))
+
+        return LambdaLR(optimizer, lr_lambda)
+    if training_cfg.lr_scheduler in (None, "none"):
+        return None
+    raise ValueError(f"Unsupported scheduler {training_cfg.lr_scheduler}")
+
+
+def compute_land_penalty(
+    land_mask: Optional[LandMask],
+    pred_lon: torch.Tensor,
+    pred_lat: torch.Tensor,
+    weight: float,
+) -> torch.Tensor:
+    if land_mask is None or weight <= 0:
+        return torch.zeros(1, device=pred_lon.device)
+
+    penalty = 0.0
+    total_points = 0
+    lon_np = pred_lon.detach().cpu().numpy()
+    lat_np = pred_lat.detach().cpu().numpy()
+    for lon_seq, lat_seq in zip(lon_np, lat_np):
+        for lon, lat in zip(lon_seq, lat_seq):
+            total_points += 1
+            if land_mask.intersects(float(lon), float(lat)):
+                penalty += 1.0
+            else:
+                distance_deg = land_mask.distance_to_land(float(lon), float(lat))
+                distance_m = distance_deg * METERS_PER_DEGREE_LAT
+                penalty += max(0.0, 1.0 - distance_m / 500.0)
+    if total_points == 0:
+        return torch.zeros(1, device=pred_lon.device)
+    penalty_tensor = torch.tensor(penalty / total_points, device=pred_lon.device)
+    return weight * penalty_tensor
+
+
+def convert_to_absolute(
+    delta_xy: torch.Tensor,
+    anchor_lon: torch.Tensor,
+    anchor_lat: torch.Tensor,
+) -> Dict[str, torch.Tensor]:
+    cumulative = delta_xy.cumsum(dim=1)
+    meters_per_deg_lon = METERS_PER_DEGREE_LAT * torch.cos(torch.deg2rad(anchor_lat))
+    meters_per_deg_lon = torch.clamp(meters_per_deg_lon, min=1e-3)
+    lon_offset = cumulative[..., 0] / meters_per_deg_lon.unsqueeze(1)
+    lat_offset = cumulative[..., 1] / METERS_PER_DEGREE_LAT
+    pred_lon = anchor_lon.unsqueeze(1) + lon_offset
+    pred_lat = anchor_lat.unsqueeze(1) + lat_offset
+    return {"lon": pred_lon, "lat": pred_lat}
+
+
+def train_one_epoch(
+    model: TrajectoryTransformer,
+    datamodule: TrajectoryDataModule,
+    optimizer: torch.optim.Optimizer,
+    scheduler: Optional[torch.optim.lr_scheduler._LRScheduler],
+    device: torch.device,
+    training_cfg: TrainingConfig,
+    land_mask: Optional[LandMask],
+) -> Dict[str, float]:
+    model.train()
+    dataloader = datamodule.dataloader(
+        "train", batch_size=training_cfg.batch_size, num_workers=training_cfg.num_workers
+    )
+    progress = tqdm(dataloader, desc="train", leave=False)
+
+    total_loss = 0.0
+    total_batches = 0
+
+    scaler = torch.cuda.amp.GradScaler(enabled=training_cfg.mixed_precision and device.type == "cuda")
+
+    for batch in progress:
+        history = batch["history"].to(device)
+        static = batch["static"].to(device)
+        future_delta = batch["future_delta"].to(device)
+        future_abs = batch["future_absolute"].to(device)
+        anchor_lon = batch["anchor_lon"].to(device)
+        anchor_lat = batch["anchor_lat"].to(device)
+
+        optimizer.zero_grad(set_to_none=True)
+
+        with torch.cuda.amp.autocast(enabled=scaler.is_enabled()):
+            outputs = model(history, static)
+            delta_pred = outputs["delta_xy"]
+            delta_loss = F.smooth_l1_loss(delta_pred, future_delta)
+            loss = delta_loss
+
+            absolute_pred = convert_to_absolute(delta_pred, anchor_lon, anchor_lat)
+            pred_lon = absolute_pred["lon"]
+            pred_lat = absolute_pred["lat"]
+
+            target_lon = future_abs[..., 0]
+            target_lat = future_abs[..., 1]
+            geo_error = haversine_distance(pred_lon, pred_lat, target_lon, target_lat)
+            geodesic_loss = geo_error.mean()
+            loss = loss + model.config.geodesic_loss_weight * geodesic_loss
+
+            if "speed" in outputs and "future_speed" in batch:
+                speed_loss = F.smooth_l1_loss(outputs["speed"], batch["future_speed"].to(device))
+                loss = loss + model.config.velocity_loss_weight * speed_loss
+
+            if "heading" in outputs and "future_course" in batch:
+                course_rad = torch.deg2rad(batch["future_course"].to(device))
+                target_heading = torch.stack([torch.sin(course_rad), torch.cos(course_rad)], dim=-1)
+                heading_loss = F.mse_loss(outputs["heading"], target_heading)
+                loss = loss + model.config.velocity_loss_weight * 0.5 * heading_loss
+
+            land_penalty = compute_land_penalty(land_mask, pred_lon, pred_lat, model.config.land_penalty_weight)
+            loss = loss + land_penalty
+
+            if "destination_logits" in outputs and "destination" in batch:
+                destination_loss = F.cross_entropy(
+                    outputs["destination_logits"], batch["destination"].to(device)
+                )
+                loss = loss + model.config.destination_loss_weight * destination_loss
+
+        scaler.scale(loss).backward()
+        scaler.unscale_(optimizer)
+        if training_cfg.max_grad_norm:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), training_cfg.max_grad_norm)
+        scaler.step(optimizer)
+        scaler.update()
+        if scheduler is not None:
+            scheduler.step()
+
+        total_loss += float(loss.detach())
+        total_batches += 1
+        progress.set_postfix({"loss": total_loss / total_batches})
+
+    return {"loss": total_loss / max(total_batches, 1)}
+
+
+def evaluate(
+    model: TrajectoryTransformer,
+    datamodule: TrajectoryDataModule,
+    split: str,
+    device: torch.device,
+    land_mask: Optional[LandMask],
+) -> Dict[str, float]:
+    model.eval()
+    dataloader = datamodule.dataloader(split, batch_size=128, num_workers=0)
+    total_loss = 0.0
+    total_geo = 0.0
+    total_final = 0.0
+    total_batches = 0
+    within_one_nm = 0
+    total_sequences = 0
+
+    with torch.no_grad():
+        for batch in tqdm(dataloader, desc=split, leave=False):
+            history = batch["history"].to(device)
+            static = batch["static"].to(device)
+            future_delta = batch["future_delta"].to(device)
+            future_abs = batch["future_absolute"].to(device)
+            anchor_lon = batch["anchor_lon"].to(device)
+            anchor_lat = batch["anchor_lat"].to(device)
+
+            outputs = model(history, static)
+            delta_pred = outputs["delta_xy"]
+            delta_loss = F.smooth_l1_loss(delta_pred, future_delta)
+
+            absolute_pred = convert_to_absolute(delta_pred, anchor_lon, anchor_lat)
+            pred_lon = absolute_pred["lon"]
+            pred_lat = absolute_pred["lat"]
+            target_lon = future_abs[..., 0]
+            target_lat = future_abs[..., 1]
+
+            geo_error = haversine_distance(pred_lon, pred_lat, target_lon, target_lat)
+            geodesic_loss = geo_error.mean()
+
+            final_error = geo_error[:, -1].mean()
+            within_one_nm += (geo_error[:, -1] < NAUTICAL_MILE_METERS).sum().item()
+            total_sequences += geo_error.shape[0]
+
+            total_loss += float(delta_loss)
+            total_geo += float(geodesic_loss)
+            total_final += float(final_error)
+            total_batches += 1
+
+    metrics = {
+        "loss": total_loss / max(total_batches, 1),
+        "geodesic": total_geo / max(total_batches, 1),
+        "final_error": total_final / max(total_batches, 1),
+        "within_1nm": within_one_nm / max(total_sequences, 1),
+    }
+    return metrics
+
+
+def save_checkpoint(path: Path, model: TrajectoryTransformer, optimizer: torch.optim.Optimizer) -> None:
+    payload = {
+        "model_state": model.state_dict(),
+        "optimizer_state": optimizer.state_dict(),
+        "config": asdict(model.config),
+    }
+    torch.save(payload, path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train trajectory transformer")
+    parser.add_argument("--config", type=Path, required=True, help="Path to YAML config")
+    parser.add_argument("--output", type=Path, default=Path("outputs"), help="Directory for checkpoints")
+    args = parser.parse_args()
+
+    experiment = load_config(args.config)
+    set_seed(experiment.data.random_seed)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    land_mask = None
+    if experiment.data.geojson_path:
+        land_mask = LandMask(Path(experiment.data.geojson_path))
+
+    datamodule = TrajectoryDataModule(experiment.data, land_mask)
+    datamodule.setup()
+
+    if datamodule.train_dataset is None:
+        raise RuntimeError("Training dataset could not be created")
+    if experiment.model.predict_steps != datamodule.train_dataset.predict_steps:
+        raise ValueError(
+            "Model predict_steps must match data forecast horizon; "
+            f"got model={experiment.model.predict_steps} data={datamodule.train_dataset.predict_steps}"
+        )
+
+    model = TrajectoryTransformer(experiment.model, datamodule.encoder.embedding_dims)
+    model.to(device)
+
+    optimizer = AdamW(
+        model.parameters(),
+        lr=experiment.training.learning_rate,
+        weight_decay=experiment.training.weight_decay,
+    )
+
+    total_steps = len(datamodule.train_dataset) // experiment.training.batch_size
+    total_steps = max(total_steps, 1) * experiment.training.num_epochs
+    scheduler = create_scheduler(optimizer, experiment.training, total_steps)
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    best_val_error = math.inf
+    best_checkpoint = args.output / "best.pt"
+
+    for epoch in range(1, experiment.training.num_epochs + 1):
+        train_metrics = train_one_epoch(
+            model,
+            datamodule,
+            optimizer,
+            scheduler,
+            device,
+            experiment.training,
+            land_mask,
+        )
+        val_metrics = evaluate(model, datamodule, "val", device, land_mask)
+
+        tqdm.write(
+            f"Epoch {epoch}: train_loss={train_metrics['loss']:.4f} val_geo={val_metrics['geodesic']:.2f}m "
+            f"val_final={val_metrics['final_error']:.2f}m within_1nm={val_metrics['within_1nm']*100:.1f}%"
+        )
+
+        if val_metrics["final_error"] < best_val_error:
+            best_val_error = val_metrics["final_error"]
+            save_checkpoint(best_checkpoint, model, optimizer)
+
+    test_metrics = evaluate(model, datamodule, "test", device, land_mask)
+    tqdm.write(
+        f"Test: geo={test_metrics['geodesic']:.2f}m final={test_metrics['final_error']:.2f}m within_1nm={test_metrics['within_1nm']*100:.1f}%"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a reusable ship_trajectory package with configuration, dataset preprocessing, geo-fence handling, and transformer model
- provide a training script with land-avoidance penalties, destination classification, and evaluation metrics
- document usage with a README, requirements, and an example configuration file

## Testing
- python -m compileall ship_trajectory

------
https://chatgpt.com/codex/tasks/task_e_68d8bf5c1cdc832f9d51ee8b56e7dc8a